### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install httpx pytest flake8
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running on pushes and PRs to `main`
- install dependencies and run linting and tests in CI

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68823075fd6483319043f82440989745