### PR TITLE
Add OpenAPI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install httpx pytest flake8
+          pip install pyyaml
       - name: Lint
         run: flake8
       - name: Test
         run: pytest -q
+      - name: Validate OpenAPI
+        run: python scripts/validate_openapi.py

--- a/api.yaml
+++ b/api.yaml
@@ -1,0 +1,143 @@
+openapi: 3.1.0
+info:
+  title: FastAPI
+  version: 0.1.0
+paths:
+  /v1/mappings/{service}:
+    post:
+      summary: Map Ids
+      operationId: map_ids_v1_mappings__service__post
+      parameters:
+      - name: service
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/MappingType'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MappingRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MappingResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    MapEntry:
+      properties:
+        mappedIdType:
+          type: string
+          title: Mappedidtype
+        mappedIdValue:
+          type: string
+          title: Mappedidvalue
+        sources:
+          items:
+            type: string
+            maxLength: 2083
+            minLength: 1
+            format: uri
+          type: array
+          title: Sources
+      type: object
+      required:
+      - mappedIdType
+      - mappedIdValue
+      - sources
+      title: MapEntry
+    MappingJob:
+      properties:
+        idType:
+          type: string
+          enum:
+          - CUSIP
+          - ISIN
+          - FIGI
+          - FIGI_COMPOSITE
+          - FIGI_SHARE_CLASS
+          title: Idtype
+        idValue:
+          type: string
+          title: Idvalue
+      type: object
+      required:
+      - idType
+      - idValue
+      title: MappingJob
+    MappingRequest:
+      properties:
+        jobs:
+          items:
+            $ref: '#/components/schemas/MappingJob'
+          type: array
+          title: Jobs
+      type: object
+      required:
+      - jobs
+      title: MappingRequest
+    MappingResponse:
+      properties:
+        results:
+          items:
+            $ref: '#/components/schemas/MapEntry'
+          type: array
+          title: Results
+      type: object
+      required:
+      - results
+      title: MappingResponse
+    MappingType:
+      type: string
+      enum:
+      - cusip2figi
+      - cusip2figicomposite
+      - cusip2figishareclass
+      - isin2figi
+      - isin2figicomposite
+      - isin2figishareclass
+      - figi2cusip
+      - figi2isin
+      - figi2figicomposite
+      - figi2figishareclass
+      title: MappingType
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError

--- a/scripts/validate_openapi.py
+++ b/scripts/validate_openapi.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.main import app  # noqa: E402
+
+
+def main() -> int:
+    current_schema = app.openapi()
+    with open('api.yaml', 'r') as f:
+        saved_schema = yaml.safe_load(f)
+    if current_schema != saved_schema:
+        print('OpenAPI schema mismatch. Please regenerate api.yaml')
+        return 1
+    print('OpenAPI schema matches api.yaml')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- generate `api.yaml` from FastAPI app
- add validation script to check that the generated OpenAPI schema matches `api.yaml`
- install PyYAML in CI and run validation step

## Testing
- `flake8 && pytest -q && python scripts/validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_b_6882466276508331943a3de6da5e82a5