### PR TITLE
Add Railway deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn src.main:app --host 0.0.0.0 --port $PORT

--- a/README.md
+++ b/README.md
@@ -10,11 +10,21 @@ Install dependencies and run the application:
 
 ```bash
 pip install -r requirements.txt
-uvicorn app.main:app --reload
+uvicorn src.main:app --reload
 ```
 
 Run tests with:
 
 ```bash
 pytest
+```
+
+## Deployment
+
+The repository includes a `Procfile` for deployment on [Railway](https://railway.app/).
+Railway automatically sets the `PORT` environment variable, so the application
+can be started with:
+
+```bash
+uvicorn src.main:app --host 0.0.0.0 --port $PORT
 ```

--- a/src/main.py
+++ b/src/main.py
@@ -1,18 +1,30 @@
+"""Application entry point."""
+
 from fastapi import FastAPI
 
 from .routers.mapping import router as mapping_router
 
 
 def create_app() -> FastAPI:
-    app = FastAPI()
-    app.include_router(mapping_router)
-    return app
+    """Construct and configure the FastAPI application."""
+
+    application = FastAPI()
+    application.include_router(mapping_router)
+    return application
 
 
 app = create_app()
 
 
-if __name__ == "__main__":  # pragma: no cover
+def main() -> None:  # pragma: no cover - manual start
+    """Run the application with uvicorn."""
+
+    import os
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    port = int(os.environ.get("PORT", "8000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Procfile for Railway deployments
- document Railway setup and correct local `uvicorn` invocation
- factor the application runner into a `main` function with env `PORT`

## Testing
- `ruff check --fix src/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882557b9a548331ba9fb72351a2676a