### PR TITLE
Add global rate limit middleware

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,12 +3,16 @@
 from fastapi import FastAPI
 
 from .routers.mapping import router as mapping_router
+from .utils.ratelimit_middleware import RateLimitMiddleware
 
 
 def create_app() -> FastAPI:
     """Construct and configure the FastAPI application."""
 
     application = FastAPI()
+    application.add_middleware(
+        RateLimitMiddleware, max_requests=60, window_seconds=60
+    )
     application.include_router(mapping_router)
     return application
 

--- a/src/utils/ratelimit_middleware.py
+++ b/src/utils/ratelimit_middleware.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque
+import asyncio
+import time
+
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Simple in-memory rate limiting middleware."""
+
+    def __init__(
+        self, app: ASGIApp, max_requests: int, window_seconds: int
+    ) -> None:
+        super().__init__(app)
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._timestamps: Deque[float] = deque()
+        self._lock = asyncio.Lock()
+
+    async def dispatch(self, request: Request, call_next):
+        now = time.monotonic()
+        async with self._lock:
+            while (
+                self._timestamps
+                and now - self._timestamps[0] > self.window_seconds
+            ):
+                self._timestamps.popleft()
+            if len(self._timestamps) >= self.max_requests:
+                return JSONResponse(
+                    {"detail": "Too Many Requests"}, status_code=429
+                )
+            self._timestamps.append(now)
+        return await call_next(request)

--- a/tests/test_mapping_router.py
+++ b/tests/test_mapping_router.py
@@ -6,9 +6,9 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 from fastapi.testclient import TestClient  # noqa: E402
-from src.main import app  # noqa: E402
+from src.main import create_app  # noqa: E402
 
-client = TestClient(app)
+client = TestClient(create_app())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+from src.main import create_app  # noqa: E402
+
+
+def test_global_rate_limit() -> None:
+    client = TestClient(create_app())
+    payload = {"jobs": [{"idType": "CUSIP", "idValue": "12345678"}]}
+    for _ in range(60):
+        response = client.post("/v1/mappings/cusip2figi", json=payload)
+        assert response.status_code == 200
+    response = client.post("/v1/mappings/cusip2figi", json=payload)
+    assert response.status_code == 429


### PR DESCRIPTION
## Summary
- add a simple in-memory rate limiting middleware
- wire middleware into FastAPI app
- update existing router tests to create a new app per run
- add test verifying rate limit behavior

## Testing
- `flake8`
- `pytest -q`
- `python scripts/validate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_b_68825f37db4c8331b1eae16c9e05cf7c