### PR TITLE
Connect to real APIs for identifier mapping

### DIFF
--- a/src/clients/financedb_client.py
+++ b/src/clients/financedb_client.py
@@ -1,18 +1,50 @@
 from typing import List
 
+import financedatabase as fd
+
 from ..schemas.mapping_request import MappingRequest
 from ..schemas.mapping_response import MapEntry
 
 
 class FinanceDbClient:
+    """Client for the FinanceDatabase dataset."""
+
+    def __init__(self) -> None:
+        self._equities = fd.Equities().select()
+
     async def fetch_mappings(self, jobs: MappingRequest) -> List[MapEntry]:
         results: List[MapEntry] = []
         for job in jobs.jobs:
-            results.append(
-                MapEntry(
-                    mappedIdType="TICKER",
-                    mappedIdValue=f"FAKE-{job.idValue}",
-                    sources=["https://finance.db"]
+            df = self._equities[
+                (self._equities["figi"] == job.idValue)
+                | (self._equities["composite_figi"] == job.idValue)
+                | (self._equities["shareclass_figi"] == job.idValue)
+            ]
+            if df.empty:
+                results.append(
+                    MapEntry(
+                        mappedIdType="CUSIP",
+                        mappedIdValue=None,
+                        sources=["https://www.jeroenbouma.com/projects/financedatabase"],
+                        error="No mapping found",
+                    )
                 )
-            )
+                continue
+            for _, row in df.iterrows():
+                if row.get("cusip"):
+                    results.append(
+                        MapEntry(
+                            mappedIdType="CUSIP",
+                            mappedIdValue=str(row["cusip"]),
+                            sources=["https://www.jeroenbouma.com/projects/financedatabase"],
+                        )
+                    )
+                if row.get("isin"):
+                    results.append(
+                        MapEntry(
+                            mappedIdType="ISIN",
+                            mappedIdValue=str(row["isin"]),
+                            sources=["https://www.jeroenbouma.com/projects/financedatabase"],
+                        )
+                    )
         return results

--- a/src/clients/openfigi_client.py
+++ b/src/clients/openfigi_client.py
@@ -4,27 +4,60 @@ import httpx
 
 from ..schemas.mapping_request import MappingRequest
 from ..schemas.mapping_response import MapEntry
+from ..config import settings
 
 
 class OpenFigiClient:
     BASE_URL = "https://api.openfigi.com/v3/mapping"
 
     def __init__(self) -> None:
-        self._client = httpx.AsyncClient()
+        headers = {}
+        if settings.openfigi_api_key:
+            headers["X-OPENFIGI-APIKEY"] = settings.openfigi_api_key
+        self._client = httpx.AsyncClient(headers=headers)
 
     async def close(self) -> None:
         await self._client.aclose()
 
     async def fetch_mappings(self, jobs: MappingRequest) -> List[MapEntry]:
-        # Minimal placeholder implementation
-        # Would normally call the OpenFIGI API
-        results: List[MapEntry] = []
-        for job in jobs.jobs:
-            results.append(
+        """Fetch FIGI mappings from the OpenFIGI service."""
+
+        payload = [
+            {"idType": f"ID_{job.idType}", "idValue": job.idValue}
+            for job in jobs.jobs
+        ]
+        try:
+            resp = await self._client.post(self.BASE_URL, json=payload)
+            resp.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network errors
+            return [
                 MapEntry(
                     mappedIdType="FIGI",
-                    mappedIdValue=f"FAKE-{job.idValue}",
-                    sources=["https://openfigi.com"]
+                    mappedIdValue=None,
+                    sources=["https://api.openfigi.com/v3/mapping"],
+                    error=str(exc),
                 )
-            )
+            ]
+
+        results: List[MapEntry] = []
+        for item in resp.json():
+            if "data" in item:
+                for entry in item["data"]:
+                    results.append(
+                        MapEntry(
+                            mappedIdType="FIGI",
+                            mappedIdValue=entry.get("figi"),
+                            sources=["https://api.openfigi.com/v3/mapping"],
+                        )
+                    )
+            else:
+                results.append(
+                    MapEntry(
+                        mappedIdType="FIGI",
+                        mappedIdValue=None,
+                        sources=["https://api.openfigi.com/v3/mapping"],
+                        error=item.get("error", "No mapping found"),
+                    )
+                )
+
         return results

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/src/main.py
+++ b/src/main.py
@@ -6,12 +6,12 @@ from .routers.enrichment import router as enrichment_router
 from .utils.ratelimit_middleware import RateLimitMiddleware
 
 
-def create_app() -> FastAPI:
+def create_app(max_requests: int = 60, window_seconds: int = 60) -> FastAPI:
     """Construct and configure the FastAPI application."""
 
     application = FastAPI()
     application.add_middleware(
-        RateLimitMiddleware, max_requests=60, window_seconds=60
+        RateLimitMiddleware, max_requests=max_requests, window_seconds=window_seconds
     )
     application.include_router(enrichment_router)
     return application

--- a/src/schemas/mapping_response.py
+++ b/src/schemas/mapping_response.py
@@ -5,8 +5,9 @@ from pydantic import BaseModel, HttpUrl
 
 class MapEntry(BaseModel):
     mappedIdType: str
-    mappedIdValue: str
+    mappedIdValue: str | None = None
     sources: List[HttpUrl]
+    error: str | None = None
 
 
 class MappingResponse(BaseModel):

--- a/src/utils/merge_sources.py
+++ b/src/utils/merge_sources.py
@@ -5,7 +5,11 @@ from ..schemas.mapping_response import MapEntry
 
 def merge_sources(entries: List[MapEntry]) -> List[MapEntry]:
     merged: dict[tuple[str, str], MapEntry] = {}
+    others: List[MapEntry] = []
     for entry in entries:
+        if entry.mappedIdValue is None:
+            others.append(entry)
+            continue
         key = (entry.mappedIdType, entry.mappedIdValue)
         if key not in merged:
             merged[key] = MapEntry(
@@ -17,4 +21,4 @@ def merge_sources(entries: List[MapEntry]) -> List[MapEntry]:
             for src in entry.sources:
                 if src not in merged[key].sources:
                     merged[key].sources.append(src)
-    return list(merged.values())
+    return list(merged.values()) + others

--- a/tests/test_enrichment_router.py
+++ b/tests/test_enrichment_router.py
@@ -14,8 +14,8 @@ client = TestClient(create_app())
 @pytest.mark.parametrize(
     "id_type,id_value",
     [
-        ("CUSIP", "12345678"),
-        ("FIGI", "BBG000CL9VN4"),
+        ("CUSIP", "037833100"),  # Apple Inc.
+        ("FIGI", "BBG000B9XRY4"),
     ],
 )
 def test_enrichment_router(id_type: str, id_value: str) -> None:
@@ -23,4 +23,4 @@ def test_enrichment_router(id_type: str, id_value: str) -> None:
     response = client.post("/v1/enrich", json=payload)
     assert response.status_code == 200
     data = response.json()
-    assert data["results"][0]["mappedIdValue"] == f"FAKE-{id_value}"
+    assert data["results"][0]["mappedIdValue"] is not None

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -8,19 +8,19 @@ from src.schemas.mapping_request import MappingJob, MappingRequest
 async def test_openfigi_service_mapping():
     service = OpenFigiService()
     jobs = MappingRequest(jobs=[
-        MappingJob(idType="CUSIP", idValue="12345678")
+        MappingJob(idType="CUSIP", idValue="037833100")
     ])
     results = await service.map(jobs)
-    assert results[0].mappedIdValue == "FAKE-12345678"
-    assert str(results[0].sources[0]) == "https://openfigi.com/"
+    assert results[0].mappedIdValue is not None
+    assert "openfigi" in str(results[0].sources[0])
 
 
 @pytest.mark.asyncio
 async def test_financedb_service_mapping():
     service = FinanceDbService()
     jobs = MappingRequest(jobs=[
-        MappingJob(idType="CUSIP", idValue="87654321")
+        MappingJob(idType="FIGI", idValue="BBG000B9XRY4")
     ])
     results = await service.map(jobs)
-    assert results[0].mappedIdValue == "FAKE-87654321"
-    assert str(results[0].sources[0]) == "https://finance.db/"
+    assert results[0].mappedIdValue is not None
+    assert "financedatabase" in str(results[0].sources[0])

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -8,9 +8,9 @@ from src.main import create_app  # noqa: E402
 
 
 def test_global_rate_limit() -> None:
-    client = TestClient(create_app())
-    payload = {"jobs": [{"idType": "CUSIP", "idValue": "12345678"}]}
-    for _ in range(60):
+    client = TestClient(create_app(max_requests=2, window_seconds=10))
+    payload = {"jobs": [{"idType": "CUSIP", "idValue": "037833100"}]}
+    for _ in range(2):
         response = client.post("/v1/enrich", json=payload)
         assert response.status_code == 200
     response = client.post("/v1/enrich", json=payload)


### PR DESCRIPTION
## Summary
- use real OpenFIGI API via httpx
- query FinanceDatabase for FIGI mappings
- support optional errors and null values in mapping responses
- allow RateLimitMiddleware config via `create_app`
- update unit tests for real data lookups

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688266bf6ae08331bb7731a1ea721fa5