### PR TITLE
Refactor enrichment endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Symbol Mapping
 
 This project implements a small FastAPI service for identifier enrichment. It
-exposes a single `POST /v1/enrich` endpoint that accepts a list of mapping jobs
+exposes a single `POST /v1/enrich` endpoint that accepts an identifier payload
 and returns mapped identifiers.
 
 ## Development

--- a/api.yaml
+++ b/api.yaml
@@ -65,7 +65,7 @@ components:
       - mappedIdType
       - sources
       title: MapEntry
-    MappingJob:
+    MappingRequest:
       properties:
         idType:
           type: string
@@ -83,18 +83,8 @@ components:
       required:
       - idType
       - idValue
-      title: MappingJob
-    MappingRequest:
-      properties:
-        jobs:
-          items:
-            $ref: '#/components/schemas/MappingJob'
-          type: array
-          title: Jobs
-      type: object
-      required:
-      - jobs
       title: MappingRequest
+      description: Request payload for a single identifier.
     MappingResponse:
       properties:
         results:

--- a/src/clients/financedb_client.py
+++ b/src/clients/financedb_client.py
@@ -14,25 +14,23 @@ class FinanceDbClient:
     def __init__(self) -> None:
         self._equities = fd.Equities().select()
 
-    async def fetch_mappings(self, jobs: MappingRequest) -> List[MapEntry]:
+    async def fetch_mappings(self, request: MappingRequest) -> List[MapEntry]:
         results: List[MapEntry] = []
-        for job in jobs.jobs:
-            df = self._equities[
-                (self._equities["figi"] == job.idValue)
-                | (self._equities["composite_figi"] == job.idValue)
-                | (self._equities["shareclass_figi"] == job.idValue)
-            ]
-            if df.empty:
-                results.append(
-                    MapEntry(
-                        mappedIdType="CUSIP",
-                        mappedIdValue=None,
-                        sources=[FINANCEDB_SOURCE],
-                        error="No mapping found",
-                    )
+        df = self._equities[
+            (self._equities["figi"] == request.idValue)
+            | (self._equities["composite_figi"] == request.idValue)
+            | (self._equities["shareclass_figi"] == request.idValue)
+        ]
+        if df.empty:
+            results.append(
+                MapEntry(
+                    mappedIdType="CUSIP",
+                    mappedIdValue=None,
+                    sources=[FINANCEDB_SOURCE],
+                    error="No mapping found",
                 )
-                continue
-
+            )
+        else:
             filtered = df[["cusip", "isin"]].dropna(how="all")
             for cusip, isin in filtered.itertuples(index=False):
                 if cusip:
@@ -51,5 +49,4 @@ class FinanceDbClient:
                             sources=[FINANCEDB_SOURCE],
                         )
                     )
-
         return results

--- a/src/clients/openfigi_client.py
+++ b/src/clients/openfigi_client.py
@@ -19,12 +19,11 @@ class OpenFigiClient:
     async def close(self) -> None:
         await self._client.aclose()
 
-    async def fetch_mappings(self, jobs: MappingRequest) -> List[MapEntry]:
+    async def fetch_mappings(self, request: MappingRequest) -> List[MapEntry]:
         """Fetch FIGI mappings from the OpenFIGI service."""
 
         payload = [
-            {"idType": f"ID_{job.idType}", "idValue": job.idValue}
-            for job in jobs.jobs
+            {"idType": f"ID_{request.idType}", "idValue": request.idValue}
         ]
         try:
             resp = await self._client.post(self.BASE_URL, json=payload)

--- a/src/routers/enrichment.py
+++ b/src/routers/enrichment.py
@@ -11,8 +11,8 @@ router = APIRouter(prefix="/v1/enrich")
 
 @router.post("", response_model=MappingResponse)
 async def enrich(
-    jobs: MappingRequest,
+    payload: MappingRequest,
     svc: EnrichmentService = Depends(get_enrichment_service),
 ) -> MappingResponse:
-    raw = await svc.enrich(jobs)
+    raw = await svc.enrich(payload)
     return MappingResponse(results=merge_sources(raw))

--- a/src/schemas/mapping_request.py
+++ b/src/schemas/mapping_request.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -11,10 +11,8 @@ AllowedIdType = Literal[
 ]
 
 
-class MappingJob(BaseModel):
+class MappingRequest(BaseModel):
+    """Request payload for a single identifier."""
+
     idType: AllowedIdType
     idValue: str
-
-
-class MappingRequest(BaseModel):
-    jobs: List[MappingJob]

--- a/src/services/base_service.py
+++ b/src/services/base_service.py
@@ -5,7 +5,7 @@ from ..schemas.mapping_response import MapEntry
 
 
 class MappingService:
-    async def map(self, jobs: MappingRequest) -> List[MapEntry]:
+    async def map(self, request: MappingRequest) -> List[MapEntry]:
         """Map identifiers."""
         # pragma: no cover - interface
         raise NotImplementedError

--- a/src/services/figi_service.py
+++ b/src/services/figi_service.py
@@ -10,5 +10,5 @@ class OpenFigiService(MappingService):
     def __init__(self) -> None:
         self.client = OpenFigiClient()
 
-    async def map(self, jobs: MappingRequest) -> List[MapEntry]:
-        return await self.client.fetch_mappings(jobs)
+    async def map(self, request: MappingRequest) -> List[MapEntry]:
+        return await self.client.fetch_mappings(request)

--- a/src/services/financedb_service.py
+++ b/src/services/financedb_service.py
@@ -10,5 +10,5 @@ class FinanceDbService(MappingService):
     def __init__(self) -> None:
         self.client = FinanceDbClient()
 
-    async def map(self, jobs: MappingRequest) -> List[MapEntry]:
-        return await self.client.fetch_mappings(jobs)
+    async def map(self, request: MappingRequest) -> List[MapEntry]:
+        return await self.client.fetch_mappings(request)

--- a/tests/test_enrichment_router.py
+++ b/tests/test_enrichment_router.py
@@ -19,7 +19,7 @@ client = TestClient(create_app())
     ],
 )
 def test_enrichment_router(id_type: str, id_value: str) -> None:
-    payload = {"jobs": [{"idType": id_type, "idValue": id_value}]}
+    payload = {"idType": id_type, "idValue": id_value}
     response = client.post("/v1/enrich", json=payload)
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -1,16 +1,14 @@
 from src.services.figi_service import OpenFigiService
 from src.services.financedb_service import FinanceDbService
 import pytest
-from src.schemas.mapping_request import MappingJob, MappingRequest
+from src.schemas.mapping_request import MappingRequest
 
 
 @pytest.mark.asyncio
 async def test_openfigi_service_mapping():
     service = OpenFigiService()
-    jobs = MappingRequest(jobs=[
-        MappingJob(idType="CUSIP", idValue="037833100")
-    ])
-    results = await service.map(jobs)
+    request = MappingRequest(idType="CUSIP", idValue="037833100")
+    results = await service.map(request)
     assert results[0].mappedIdValue is not None
     assert "openfigi" in str(results[0].sources[0])
 
@@ -18,9 +16,7 @@ async def test_openfigi_service_mapping():
 @pytest.mark.asyncio
 async def test_financedb_service_mapping():
     service = FinanceDbService()
-    jobs = MappingRequest(jobs=[
-        MappingJob(idType="FIGI", idValue="BBG000B9XRY4")
-    ])
-    results = await service.map(jobs)
+    request = MappingRequest(idType="FIGI", idValue="BBG000B9XRY4")
+    results = await service.map(request)
     assert results[0].mappedIdValue is not None
     assert "financedatabase" in str(results[0].sources[0])

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -9,7 +9,7 @@ from src.main import create_app  # noqa: E402
 
 def test_global_rate_limit() -> None:
     client = TestClient(create_app(max_requests=2, window_seconds=1000))
-    payload = {"jobs": [{"idType": "CUSIP", "idValue": "037833100"}]}
+    payload = {"idType": "CUSIP", "idValue": "037833100"}
     for _ in range(2):
         response = client.post("/v1/enrich", json=payload)
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
- refactor API to accept a single identifier instead of job list
- update enrichment service logic
- adjust clients and services for new payload
- update tests and OpenAPI schema

## Testing
- `flake8`
- `pytest -q`
- `python scripts/validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_b_68828026227c8331b87adcbec0420e57