### PR TITLE
Prune duplicate mapping entries

### DIFF
--- a/src/routers/enrichment.py
+++ b/src/routers/enrichment.py
@@ -4,7 +4,7 @@ from ..dependencies import get_enrichment_service
 from ..schemas.mapping_request import MappingRequest
 from ..schemas.mapping_response import MappingResponse
 from ..services.enrichment_service import EnrichmentService
-from ..utils.merge_sources import merge_sources
+from ..utils.merge_sources import merge_sources, prune_duplicates
 
 router = APIRouter(prefix="/v1/enrich")
 
@@ -15,4 +15,5 @@ async def enrich(
     svc: EnrichmentService = Depends(get_enrichment_service),
 ) -> MappingResponse:
     raw = await svc.enrich(payload)
-    return MappingResponse(results=merge_sources(raw))
+    merged = merge_sources(raw)
+    return MappingResponse(results=prune_duplicates(merged))

--- a/src/utils/merge_sources.py
+++ b/src/utils/merge_sources.py
@@ -1,24 +1,52 @@
-from typing import List
+"""Utilities for manipulating mapping entries."""
+
+from typing import Iterable, List
 
 from ..schemas.mapping_response import MapEntry
 
 
-def merge_sources(entries: List[MapEntry]) -> List[MapEntry]:
+def prune_duplicates(entries: Iterable[MapEntry]) -> List[MapEntry]:
+    """Remove entries that are identical in all fields."""
+
+    unique: list[MapEntry] = []
+    seen: set[tuple[str, str | None, tuple[str, ...], str | None]] = set()
+
+    for entry in entries:
+        key = (
+            entry.mappedIdType,
+            entry.mappedIdValue,
+            tuple(entry.sources),
+            entry.error,
+        )
+        if key not in seen:
+            seen.add(key)
+            unique.append(entry)
+
+    return unique
+
+
+def merge_sources(entries: Iterable[MapEntry]) -> List[MapEntry]:
+    """Merge source URLs for entries with the same type and value."""
+
     merged: dict[tuple[str, str], MapEntry] = {}
-    others: List[MapEntry] = []
+    others: list[MapEntry] = []
+
     for entry in entries:
         if entry.mappedIdValue is None:
             others.append(entry)
             continue
+
         key = (entry.mappedIdType, entry.mappedIdValue)
-        if key not in merged:
-            merged[key] = MapEntry(
+        result = merged.get(key)
+        if not result:
+            result = merged[key] = MapEntry(
                 mappedIdType=entry.mappedIdType,
                 mappedIdValue=entry.mappedIdValue,
                 sources=list(entry.sources),
             )
         else:
             for src in entry.sources:
-                if src not in merged[key].sources:
-                    merged[key].sources.append(src)
+                if src not in result.sources:
+                    result.sources.append(src)
+
     return list(merged.values()) + others

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,13 +4,28 @@ from src.utils.merge_sources import merge_sources, prune_duplicates
 
 def test_prune_duplicates():
     entries = [
-        MapEntry(mappedIdType="CUSIP", mappedIdValue="1", sources=["http://a.com"]),
-        MapEntry(mappedIdType="CUSIP", mappedIdValue="1", sources=["http://a.com"]),
-        MapEntry(mappedIdType="CUSIP", mappedIdValue="1", sources=["http://b.com"]),
+        MapEntry(
+            mappedIdType="CUSIP",
+            mappedIdValue="1",
+            sources=["http://a.com"],
+        ),
+        MapEntry(
+            mappedIdType="CUSIP",
+            mappedIdValue="1",
+            sources=["http://a.com"],
+        ),
+        MapEntry(
+            mappedIdType="CUSIP",
+            mappedIdValue="1",
+            sources=["http://b.com"],
+        ),
     ]
 
     merged = merge_sources(entries)
     unique = prune_duplicates(merged)
 
     assert len(unique) == 1
-    assert {str(u) for u in unique[0].sources} == {"http://a.com/", "http://b.com/"}
+    assert {str(url) for url in unique[0].sources} == {
+        "http://a.com/",
+        "http://b.com/",
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+from src.schemas.mapping_response import MapEntry
+from src.utils.merge_sources import merge_sources, prune_duplicates
+
+
+def test_prune_duplicates():
+    entries = [
+        MapEntry(mappedIdType="CUSIP", mappedIdValue="1", sources=["http://a.com"]),
+        MapEntry(mappedIdType="CUSIP", mappedIdValue="1", sources=["http://a.com"]),
+        MapEntry(mappedIdType="CUSIP", mappedIdValue="1", sources=["http://b.com"]),
+    ]
+
+    merged = merge_sources(entries)
+    unique = prune_duplicates(merged)
+
+    assert len(unique) == 1
+    assert {str(u) for u in unique[0].sources} == {"http://a.com/", "http://b.com/"}


### PR DESCRIPTION
## Summary
- add `prune_duplicates` utility and simplify `merge_sources`
- remove duplicate results in enrichment router
- add unit test for duplicate pruning

## Testing
- `flake8`
- `pytest -q`
- `python scripts/validate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_b_6882868cd58883318ef2ea8b995ee1de