### PR TITLE
Enable bidirectional mapping in clients

### DIFF
--- a/src/services/enrichment_service.py
+++ b/src/services/enrichment_service.py
@@ -20,17 +20,7 @@ class EnrichmentService:
 
         results: List[MapEntry] = []
 
-        if request.idType in {"CUSIP", "ISIN"}:
-            figi_entries = await self._figi.map(request)
-            results.extend(figi_entries)
-
-            figi_values = [
-                e.mappedIdValue for e in figi_entries if e.mappedIdValue
-            ]
-            for figi in figi_values:
-                req = MappingRequest(idType="FIGI", idValue=figi)
-                results.extend(await self._finance.map(req))
-        elif request.idType == "FIGI":
-            results.extend(await self._finance.map(request))
+        results.extend(await self._figi.map(request))
+        results.extend(await self._finance.map(request))
 
         return results


### PR DESCRIPTION
## Summary
- extend `FinanceDbClient` to search by all identifier types
- extend `OpenFigiClient` to return mappings for all supported id fields
- simplify `EnrichmentService` to call each service once
- keep tests passing

## Testing
- `flake8`
- `pytest -q`
- `python scripts/validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_b_68828bc557d08331a8b620214b7cda69