### PR TITLE
Add ticker to FIGI endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -26,6 +26,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /v1/mapticker:
+    post:
+      summary: Map Ticker
+      description: Map ticker/MIC pair to FIGI.
+      operationId: map_ticker_v1_mapticker_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TickerRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/MapEntry'
+                type: array
+                title: Response Map Ticker V1 Mapticker Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     HTTPValidationError:
@@ -96,6 +123,19 @@ components:
       required:
       - results
       title: MappingResponse
+    TickerRequest:
+      properties:
+        ticker:
+          type: string
+          title: Ticker
+        mic:
+          type: string
+          title: Mic
+      type: object
+      required:
+      - ticker
+      - mic
+      title: TickerRequest
     ValidationError:
       properties:
         loc:

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -1,9 +1,16 @@
 """FastAPI dependency providers."""
 
 from .services.enrichment_service import EnrichmentService
+from .services.ticker_service import TickerService
 
 
 async def get_enrichment_service() -> EnrichmentService:
     """Return an ``EnrichmentService`` instance."""
 
     return EnrichmentService()
+
+
+async def get_ticker_service() -> TickerService:
+    """Return a ``TickerService`` instance."""
+
+    return TickerService()

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 
 from .routers.enrichment import router as enrichment_router
+from .routers.mapticker import router as mapticker_router
 from .utils.ratelimit_middleware import RateLimitMiddleware
 
 
@@ -16,6 +17,7 @@ def create_app(max_requests: int = 60, window_seconds: int = 60) -> FastAPI:
         window_seconds=window_seconds,
     )
     application.include_router(enrichment_router)
+    application.include_router(mapticker_router)
     return application
 
 

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -1,0 +1,7 @@
+from .enrichment import router as enrichment_router
+from .mapticker import router as mapticker_router
+
+__all__ = [
+    "enrichment_router",
+    "mapticker_router",
+]

--- a/src/routers/mapticker.py
+++ b/src/routers/mapticker.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ..schemas.ticker_request import TickerRequest
+from ..schemas.mapping_response import MapEntry
+from ..services.ticker_service import TickerService
+from ..dependencies import get_ticker_service
+
+router = APIRouter(prefix="/v1/mapticker")
+
+
+@router.post("", response_model=list[MapEntry])
+async def map_ticker(
+    payload: TickerRequest,
+    service: TickerService = Depends(get_ticker_service),
+) -> list[MapEntry]:
+    """Map ticker/MIC pair to FIGI."""
+    return await service.map(payload)

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,0 +1,10 @@
+from .mapping_request import MappingRequest
+from .mapping_response import MappingResponse, MapEntry
+from .ticker_request import TickerRequest
+
+__all__ = [
+    "MappingRequest",
+    "MappingResponse",
+    "MapEntry",
+    "TickerRequest",
+]

--- a/src/schemas/ticker_request.py
+++ b/src/schemas/ticker_request.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class TickerRequest(BaseModel):
+    ticker: str
+    mic: str

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,11 @@
+from .enrichment_service import EnrichmentService
+from .figi_service import OpenFigiService
+from .financedb_service import FinanceDbService
+from .ticker_service import TickerService
+
+__all__ = [
+    "EnrichmentService",
+    "OpenFigiService",
+    "FinanceDbService",
+    "TickerService",
+]

--- a/src/services/ticker_service.py
+++ b/src/services/ticker_service.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from ..clients.openfigi_client import OpenFigiClient
+from ..schemas.ticker_request import TickerRequest
+from ..schemas.mapping_response import MapEntry
+from ..utils.mic_mapping import mic_to_exch
+from .base_service import MappingService
+
+
+class TickerService(MappingService):
+    """Map ticker and MIC to FIGI using OpenFIGI."""
+
+    def __init__(self) -> None:
+        self.client = OpenFigiClient()
+
+    async def map(self, request: TickerRequest) -> List[MapEntry]:
+        exch = mic_to_exch(request.mic)
+        if not exch:
+            return [self._error(f"Unknown MIC code: {request.mic}")]
+
+        try:
+            return await self.client.fetch_ticker_figi(request.ticker, exch)
+        except Exception as exc:  # pragma: no cover - network errors
+            return [self._error(str(exc))]
+
+    def _error(self, message: str) -> MapEntry:
+        return MapEntry(
+            mappedIdType="FIGI",
+            mappedIdValue=None,
+            sources=[self.client.BASE_URL],
+            error=message,
+        )

--- a/src/utils/mic_mapping.py
+++ b/src/utils/mic_mapping.py
@@ -1,0 +1,14 @@
+"""Mapping utilities for MIC to FIGI exchange codes."""
+
+MIC_TO_EXCH = {
+    "XNAS": "US",  # NASDAQ
+    "XNYS": "US",  # New York Stock Exchange
+    "ARCX": "US",  # NYSE Arca
+    "XASE": "US",  # NYSE American
+    "XLON": "LN",  # London Stock Exchange
+}
+
+
+def mic_to_exch(mic: str) -> str | None:
+    """Return the FIGI exchange code for a MIC code if known."""
+    return MIC_TO_EXCH.get(mic.upper())

--- a/tests/test_ticker_endpoint.py
+++ b/tests/test_ticker_endpoint.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+from src.main import create_app  # noqa: E402
+
+client = TestClient(create_app())
+
+
+def test_map_ticker_endpoint() -> None:
+    payload = {"ticker": "AAPL", "mic": "XNAS"}
+    response = client.post("/v1/mapticker", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["mappedIdValue"] is not None


### PR DESCRIPTION
## Summary
- add endpoint `/v1/mapticker` to map ticker and MIC to FIGI
- refactor `TickerService` with error helper
- update docs and tests for new path

## Testing
- `flake8`
- `pytest -q`
- `python scripts/validate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_b_6888d82b5a788331aebe31fafb5400bc